### PR TITLE
Fix atom feed URL (smart quotes to double quotes)

### DIFF
--- a/_includes/page_top.html
+++ b/_includes/page_top.html
@@ -11,9 +11,9 @@
 
     <link rel="stylesheet" href="/stylesheets/styles.css">
     <link rel="stylesheet" href="/stylesheets/pygment_trac.css">
-    <link rel=”alternate” type=”application/atom+xml”
-     title=”itbrokeand.ifixit.com”
-     href=”http://itbrokeand.ifixit.com/atom.xml” />
+    <link rel="alternate" type="application/atom+xml"
+     title="itbrokeand.ifixit.com"
+     href="http://itbrokeand.ifixit.com/atom.xml" />
     <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
     <!--[if lt IE 9]>
     <script src="//html5shiv.googlecode.com/svn/trunk/html5.js"></script>


### PR DESCRIPTION
I tried following your feed and my web browser thought your feed had this incorrect URL:

> http://itbrokeand.ifixit.com/%E2%80%9Dhttp://itbrokeand.ifixit.com/atom.xml%E2%80%9D

The problem is the double quotes that are wrong.
